### PR TITLE
Option for showing editor of unedefined property

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@json-editor/json-editor",
   "title": "JSONEditor",
   "description": "JSON Schema based editor",
-  "version": "2.5.3-wb4",
+  "version": "2.5.3-wb5",
   "main": "dist/jsoneditor.js",
   "author": {
     "name": "Jeremy Dorn",

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -1223,7 +1223,9 @@ export class ObjectEditor extends AbstractEditor {
         if (this.jsoneditor.options.show_opt_in || editor.options.show_opt_in) {
           editor.deactivate()
         } else {
-          this.removeObjectProperty(i)
+          if (!(editor.options.wb && editor.options.wb.show_editor)) {
+            this.removeObjectProperty(i)
+          }
         }
         /* Otherwise, set the value to the default */
       } else {


### PR DESCRIPTION
wb.show_editor can be used to show editor even if property is missing in JSON