### PR TITLE
remove ugly zero-padding from indented blocks

### DIFF
--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -80,7 +80,6 @@ export class bootstrap3Theme extends AbstractTheme {
   getIndentedPanel () {
     const el = document.createElement('div')
     el.classList.add('well', 'well-sm')
-    el.style.paddingBottom = 0
     return el
   }
 


### PR DESCRIPTION
Посмотреть результат можно тут: https://jenkins.wirenboard.com/job/wirenboard/job/homeui/job/feature%252Fjson-editor-fix-padding-bottom-in-indented-blocks/