### PR TITLE
Responsive tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@json-editor/json-editor",
   "title": "JSONEditor",
   "description": "JSON Schema based editor",
-  "version": "2.5.3-wb10",
+  "version": "2.5.3-wb11",
   "main": "dist/jsoneditor.js",
   "author": {
     "name": "Jeremy Dorn",

--- a/src/editors/table.js
+++ b/src/editors/table.js
@@ -36,8 +36,11 @@ export class TableEditor extends ArrayEditor {
   }
 
   build () {
+    this.tableContainer = this.theme.getTableContainer()
     this.table = this.theme.getTable()
-    this.container.appendChild(this.table)
+    this.tableContainer.appendChild(this.table)
+
+    this.container.appendChild(this.tableContainer)
     this.thead = this.theme.getTableHead()
     this.table.appendChild(this.thead)
     this.header_row = this.theme.getTableRow()
@@ -78,7 +81,7 @@ export class TableEditor extends ArrayEditor {
       this.container.appendChild(this.panel)
     }
 
-    this.panel.appendChild(this.table)
+    this.panel.appendChild(this.tableContainer)
     this.controls = this.theme.getButtonHolder()
     if (this.array_controls_top) {
       this.title.appendChild(this.controls)

--- a/src/theme.js
+++ b/src/theme.js
@@ -413,6 +413,10 @@ export class AbstractTheme {
     if (title) button.setAttribute('title', title)
   }
 
+  getTableContainer () {
+    return document.createElement('div')
+  }
+
   /* Table functions */
   getTable () {
     return document.createElement('table')

--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -140,6 +140,12 @@ export class bootstrap3Theme extends AbstractTheme {
     return el
   }
 
+  getTableContainer () {
+    const el = super.getTableContainer()
+    el.classList.add('table-responsive')
+    return el
+  }
+
   getTable () {
     const el = document.createElement('table')
     el.classList.add('table', 'table-bordered')

--- a/src/themes/bootstrap4.js
+++ b/src/themes/bootstrap4.js
@@ -447,6 +447,12 @@ export class bootstrap4Theme extends AbstractTheme {
     return el
   }
 
+  getTableContainer () {
+    const el = super.getTableContainer()
+    el.classList.add('table-responsive')
+    return el
+  }
+
   getTable () {
     const el = document.createElement('table')
     el.classList.add('table', 'table-sm')


### PR DESCRIPTION
Backport https://github.com/json-editor/json-editor/pull/1413

Конфиг mbgate c огромными таблицами на мобильном совсем не юзабелен, с `table-responsive` появляется хотя бы горизонтальный скрол.