### PR TITLE
feat: Update delete and copy buttons INT-927

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@wirenboard/json-editor",
   "title": "JSONEditor",
   "description": "JSON Schema based editor",
-  "version": "2.5.3-wb14",
+  "version": "2.5.3-wb15",
   "main": "dist/jsoneditor.js",
   "author": {
     "name": "Jeremy Dorn",

--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -524,7 +524,7 @@ export class ArrayEditor extends AbstractEditor {
   }
 
   _createDeleteButton (i, holder) {
-    const button = this.getButton(this.getItemTitle(), 'delete', 'button_delete_row_title', [this.getItemTitle()])
+    const button = this.getButton('button_delete_row_title_short', 'delete', 'button_delete_row_title', [this.getItemTitle()])
     button.classList.add('delete', 'json-editor-btntype-delete')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {
@@ -565,7 +565,7 @@ export class ArrayEditor extends AbstractEditor {
   }
 
   _createCopyButton (i, holder) {
-    const button = this.getButton(this.getItemTitle(), 'copy', 'button_copy_row_title', [this.getItemTitle()])
+    const button = this.getButton('button_copy_row_title_short', 'copy', 'button_copy_row_title', [this.getItemTitle()])
     button.classList.add('copy', 'json-editor-btntype-copy')
     button.setAttribute('data-i', i)
     button.addEventListener('click', e => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Is backward-compatible?    | ✔️
| Tests pass?   | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ❌

Обновлены кнопки удаления и копирования внутри схемы json-editor.

Было - Значок + Заголовок
Стало - Значок + Название действия, например Удалить или Копировать

Были проверены все схемы на обоих языках, ошибок не обнаружено. Далее прикладываю примеры нового отображения:
<img width="827" height="169" alt="1" src="https://github.com/user-attachments/assets/8330c34d-015f-4796-b516-f398ff0cdda6" />
<img width="1101" height="113" alt="2" src="https://github.com/user-attachments/assets/fb099039-a70b-46a6-8bed-d66220573118" />
<img width="1160" height="303" alt="3" src="https://github.com/user-attachments/assets/0ad4215e-1827-4f24-8849-daf1f576bc45" />
<img width="1172" height="523" alt="4" src="https://github.com/user-attachments/assets/a6b35edd-e6f8-4943-b497-574e1d31506b" />
<img width="1318" height="593" alt="5" src="https://github.com/user-attachments/assets/4a7d93e8-6821-43d2-a4c5-7244c29001db" />